### PR TITLE
remove wrong intl

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,5 +1,3 @@
 FROM php:7.4
 
-RUN apk add icu-dev
-
-RUN docker-php-ext-install pdo_mysql intl
+RUN docker-php-ext-install pdo_mysql


### PR DESCRIPTION
This is not an alpine image an crashes on build

@Pandabehr sry for the broken first pull request, it was valid until one or two days before you merged. I had added a mistake and this pull request is here to fix it.