### PR TITLE
Add PHP 8 Support

### DIFF
--- a/7.4/Dockerfile-fpm
+++ b/7.4/Dockerfile-fpm
@@ -1,0 +1,3 @@
+FROM php:7.4-fpm-alpine3.13
+
+RUN docker-php-ext-install pdo_mysql

--- a/7.4/Dockerfile-fpm
+++ b/7.4/Dockerfile-fpm
@@ -1,3 +1,3 @@
-FROM php:7.4-fpm-alpine3.13
+FROM php:7.4-fpm-alpine3.15
 
 RUN docker-php-ext-install pdo_mysql

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,3 +1,3 @@
-FROM php:8.0
+FROM php:8.0-alpine3.13
 
 RUN docker-php-ext-install pdo_mysql

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,3 +1,3 @@
-FROM php:8.0-alpine3.13
+FROM php:8.0-alpine3.15
 
 RUN docker-php-ext-install pdo_mysql

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,0 +1,3 @@
+FROM php:8.0
+
+RUN docker-php-ext-install pdo_mysql

--- a/8.0/Dockerfile-fpm
+++ b/8.0/Dockerfile-fpm
@@ -1,3 +1,3 @@
-FROM php:8.0-fpm-alpine3.13
+FROM php:8.0-fpm-alpine3.15
 
 RUN docker-php-ext-install pdo_mysql

--- a/8.0/Dockerfile-fpm
+++ b/8.0/Dockerfile-fpm
@@ -1,0 +1,3 @@
+FROM php:8.0-fpm-alpine3.13
+
+RUN docker-php-ext-install pdo_mysql


### PR DESCRIPTION
add support for php8 on alpine 
- normal
- fpm

add php7.4 fpm support

The FPM Images are in the version folders and contain the suffix ` -fpm` 